### PR TITLE
Updated the filter function to pass arguments

### DIFF
--- a/localization.js
+++ b/localization.js
@@ -128,7 +128,8 @@ angular.module('localization', [])
         {
             return function (input)
             {
-                return localize.getLocalizedString(input);
+                //also pass all the arguments
+                return localize.getLocalizedString.apply(this, arguments);
             };
         }
     ]


### PR DESCRIPTION
The filter function didn't pass all arguments to fill for placeholders so the spaces remained blank. This fixes the issue.
