### PR TITLE
Fix handling of custom filter attributes

### DIFF
--- a/localization.js
+++ b/localization.js
@@ -126,9 +126,9 @@ angular.module('localization', [])
         'localize',
         function (localize)
         {
-            return function (input)
+            return function ()
             {
-                return localize.getLocalizedString(input);
+                return localize.getLocalizedString.apply(null, arguments);
             };
         }
     ]


### PR DESCRIPTION
When called from controller with custom arguments, filter passes only first argument to the getLocalizedString() function. Due to that sprintf doesn't do it's job.

To test consider following:

```
$filter('i18n')("Hi %s, it is %s.", personA, personB);
```
