### PR TITLE
change priority to execute last

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,4 @@
+* 2015-08-07   v1.1.7   Change directive priority to be executed last
 * 2015-08-03   v1.1.6   Fixed undefined check   
 * 2015-07-23   v1.1.5   Fixed checking for section regex in string.  Added i18n.file.loaded event.  null or undefined i18n value on filter now translate to an empty string   
 * 2015-07-14   v1.1.4   Updated directive.  Breaking change on parameters.   

--- a/angular-internationalization.js
+++ b/angular-internationalization.js
@@ -533,6 +533,7 @@ angular.module('angular-i18n', ['ng'])
                 i18n: '=',
                 i18nParameters: '=?'
             },
+            priority: -1,
             restrict: "A",
             link: function (scope, elm, attrs) {
                 scope.i18nParameters = angular.extend({}, scope.i18nParameters);

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-internationalization",
   "description": "angular internationalization (i18n) provider, service, filter and directive",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "main": "angular-internationalization.js",
   "license": "MIT",
   "keyword": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-internationalization",
-  "version": "1.1.5",
+  "version": "1.1.7",
   "description": "angular i18n",
   "main": "angular-internationalization.js",
   "dependencies": {},


### PR DESCRIPTION
changed the priority to allow this directive to be used with other directives
ex: ngMessages

<div ng-message="required" i18n="'error.field.required'" i18n-parameters="{section:'settings'}"></div>